### PR TITLE
Initialize KServe folder in serving-catalog

### DIFF
--- a/serving-catalog/README.md
+++ b/serving-catalog/README.md
@@ -57,6 +57,9 @@ serving-catalog/
 │   │       └── gemma-2b
 │   │           ├── base
 │   │           └── gke
+├── kserve
+│   ├── inferenceservice
+│   └── servingruntime
 ```
 
 Where an inference deployment can be deployed using a command like:

--- a/serving-catalog/kserve/inferenceservice/README.md
+++ b/serving-catalog/kserve/inferenceservice/README.md
@@ -1,0 +1,3 @@
+# KServe Inference Services
+
+This directory contains the list of KServe InferenceServices.

--- a/serving-catalog/kserve/servingruntime/README.md
+++ b/serving-catalog/kserve/servingruntime/README.md
@@ -1,0 +1,3 @@
+# KServe Serving Runtimes
+
+This directory contains the list of KServe serving runtimes that can be deployed via [KServe InferenceServices](./inferenceservice).


### PR DESCRIPTION
This PR adds the initial folder for KServe serving catalog. The exact folder structure within the top level folders within kserve folder are still to be determined.

cc @jjk-g @ahg-g @ArangoGutierrez 