### PR TITLE
[Serving Catalog] Add llama3-8b on jetstream-pytorch

### DIFF
--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: llama3-8b-jetstream-inference-server
+  name: llama3-8b-jetstream-deployment
+spec:
+  selector:
+    matchLabels:
+      app: llama3-8b-jetstream-inference-server
+  template:
+    metadata:
+      labels:
+        app: llama3-8b-jetstream-inference-server
+    spec:
+      containers:
+      - name: inference-server
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/jetstream-pytorch-server:v0.2.3
+        args:
+        - --size=8b
+        - --model_name=llama-3
+        - --batch_size=80
+        - --max_cache_length=2048
+        - --quantize_weights=False
+        - --quantize_kv_cache=False
+        - --tokenizer_path=/models/pytorch/llama3-8b/final/bf16/tokenizer.model
+        - --checkpoint_path=/models/pytorch/llama3-8b/final/bf16/model.safetensors

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/job.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/job.patch.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Job
+metadata:
+  name: llama3-8b-jetstream-data-loader
+  labels:
+    app: llama3-8b-jetstream-data-loader
+spec:
+  template:
+    metadata:
+      labels:
+        app: llama3-8b-jetstream-data-loader
+    spec:
+      containers:
+      - name: inference-checkpoint
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.3
+        args:
+        - -s=jetstream-pytorch
+        - -m=meta-llama/Meta-Llama-3-8B
+        - -o=gs://$BUCKET_NAME/pytorch/llama3-8b/final/bf16/
+        - -n=llama-3
+        - -q=False
+        - -h=True
+        volumeMounts:
+        - mountPath: "/huggingface/"
+          name: huggingface-credentials
+          readOnly: true
+      volumes:
+        - name: huggingface-credentials
+          secret:
+            defaultMode: 0400
+            secretName: huggingface-secret

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/kustomization.yaml
@@ -1,0 +1,23 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      kind: Deployment
+    options:
+      allowNameChange: true
+  - path: job.patch.yaml
+    target:
+      kind: Job
+    options:
+      allowNameChange: true
+  - path: service.patch.yaml
+    target:
+      kind: Service
+    options:
+      allowNameChange: true

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/service.patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama3-8b-jetstream-service
+  labels:
+    app: llama3-8b-jetstream-inference-server 
+spec:
+  selector:
+    app: llama3-8b-jetstream-inference-server

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/gke/README.md
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/gke/README.md
@@ -1,0 +1,17 @@
+# llama3-8b
+
+## Configuration
+| Kind | Model Server | Model | Provider | Accelerator |
+| --- | --- | --- | --- | --- |
+| Deployment | JetStream | llama3-8b | GKE | TPU v5e 2x4 |
+
+## Usage
+$BUCKET_NAME must be replaced in `../job.patch.yaml` and `deployment.patch.yaml`
+
+The example can be deployed by issuing the commands:
+
+```
+kustomize build core/deployment/jetstream/llama3-8b/gke | kubectl apply -f - --selector prerequisite=model-load &&
+kubectl wait --for=condition=complete --timeout=1000s job/llama3-8b-jetstream-data-loader &&
+kustomize build core/deployment/jetstream/llama3-8b/gke | kubectl apply -f - --selector app=llama3-8b-jetstream-inference-server
+```

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/gke/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/gke/deployment.patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    metadata:
+      labels:
+        ai.gke.io/model: LLaMA3_8B
+        ai.gke.io/inference-server: vllm
+        examples.ai.gke.io/source: blueprints
+      annotations:
+        gke-gcsfuse/volumes: "true"
+    spec:
+      containers:
+      - name: inference-server
+        volumeMounts:
+        - name: gcs-fuse-checkpoint
+          mountPath: /models
+      volumes:
+      - name: gcs-fuse-checkpoint
+        csi:
+          driver: gcsfuse.csi.storage.gke.io
+          readOnly: true
+          volumeAttributes:
+            bucketName: $BUCKET_NAME
+            mountOptions: "implicit-dirs"

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/gke/job.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/gke/job.patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Job
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 2x4
+        cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+      containers:
+      - name: inference-checkpoint
+        resources:
+          requests:
+            google.com/tpu: 8
+          limits:
+            google.com/tpu: 8

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/gke/kustomization.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/gke/kustomization.yaml
@@ -1,0 +1,17 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ../../../components/gke/resources/tpu/v5e-2x4
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      kind: Deployment
+  - path: job.patch.yaml
+    target:
+      kind: Job


### PR DESCRIPTION
Adds llama3-8b support following https://github.com/GoogleCloudPlatform/ai-on-gke/tree/main/tutorials-and-examples/inference-servers/jetstream/pytorch/single-host-inference