### PR TITLE
Configure prometheus_port for both jetstream jax and pytorch servers

### DIFF
--- a/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/deployment.patch.yaml
@@ -15,6 +15,9 @@ spec:
     spec:
       containers:
       - name: inference-server
+        ports:
+          - containerPort: 9100
+            name: metrics
         args:
         - model_name=gemma-7b
         - tokenizer_path=assets/tokenizer.gemma
@@ -28,3 +31,4 @@ spec:
         - scan_layers=false
         - weight_dtype=bfloat16
         - load_parameters_path=gs://$BUCKET_NAME/final/unscanned/gemma_7b-it/0/checkpoints/0/items
+        - prometheus_port=9100

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
@@ -16,6 +16,9 @@ spec:
       containers:
       - name: inference-server
         image: us-docker.pkg.dev/cloud-tpu-images/inference/jetstream-pytorch-server:v0.2.3
+        ports:
+          - containerPort: 9100
+            name: metrics
         args:
         - --size=8b
         - --model_name=llama-3
@@ -25,3 +28,4 @@ spec:
         - --quantize_kv_cache=False
         - --tokenizer_path=/models/pytorch/llama3-8b/final/bf16/tokenizer.model
         - --checkpoint_path=/models/pytorch/llama3-8b/final/bf16/model.safetensors
+        - --prometheus_port=9100


### PR DESCRIPTION
The prometheus_port for pytorch server in jetstream is not documented but it's available starting v0.2.2: https://github.com/AI-Hypercomputer/JetStream/releases/tag/v0.2.2

The port number 9100 is referenced from the benchmark tool: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/main/benchmarks/inference-server/jetstream/jetstream.yaml

Please let me know if another port number is preferred.