### PR TITLE
Removing script to deploy multi-host 

### DIFF
--- a/serving-catalog/core/lws/vllm/base/configmap.yaml
+++ b/serving-catalog/core/lws/vllm/base/configmap.yaml
@@ -2,29 +2,3 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vllm-multihost-config
-data:
-  ray_status_check.sh: |-
-    #!/usr/bin/bash -x
-    # Verify ray head status
-    until ray status --address $LWS_LEADER_ADDRESS:6380; do
-      sleep 5;
-    done
-  entrypoint.sh: |-
-    #!/usr/bin/bash -x
-    # Launch vLLM Inference server
-
-    export PYTHONPATH="/workspace/"
-    if [[ -n "$1" ]]; then
-      ray start --head --port=6380
-      num_accelerators=`python3 -c 'import ray; ray.init(); print(int(sum([ray.cluster_resources().get("GPU", 0), ray.cluster_resources().get("TPU", 0)])))'`
-      total_accelerators=$(($TENSOR_PARALLEL_SIZE * $PIPELINE_PARALLEL_SIZE ))
-      until [ $num_accelerators -eq $total_accelerators ]; do
-        num_accelerators=`python3 -c 'import ray; ray.init(); print(int(sum([ray.cluster_resources().get("GPU", 0), ray.cluster_resources().get("TPU", 0)])))'`
-        sleep 5
-      done
-      python3 -m vllm.entrypoints.openai.api_server --port 8080 --model $MODEL_ID --tensor_parallel_size $TENSOR_PARALLEL_SIZE --pipeline_parallel_size $PIPELINE_PARALLEL_SIZE --trust_remote_code --max-model-len $MAX_MODEL_LEN
-    else
-      until ray start --address="$LWS_LEADER_ADDRESS":6380 --block; do
-        sleep 5
-      done
-    fi

--- a/serving-catalog/core/lws/vllm/base/leaderworkerset.patch.yaml
+++ b/serving-catalog/core/lws/vllm/base/leaderworkerset.patch.yaml
@@ -11,8 +11,10 @@ spec:
           - name: inference-server-leader
             image: vllm/vllm-openai:latest
             command:
-            - /scripts/entrypoint.sh
-            args: ["--head"]
+            - sh
+            - -c
+            - "bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size=$(LWS_GROUP_SIZE); 
+              python3 -m vllm.entrypoints.openai.api_server --port 8080 --model $(MODEL_ID) --tensor-parallel-size $(TENSOR_PARALLEL_SIZE) --pipeline_parallel_size $(PIPELINE_PARALLEL_SIZE)"
             env:
             - name: HUGGING_FACE_HUB_TOKEN
               valueFrom:
@@ -57,20 +59,13 @@ spec:
             sizeLimit: 30Gi
     workerTemplate:
       spec:
-        initContainers:
-        - name: ray-head-check
-          image: vllm/vllm-openai:latest
-          command:
-          - /scripts/ray_status_check.sh
-          volumeMounts:
-            - mountPath: "/scripts"
-              name: scripts-volume
-              readOnly: true
         containers:
           - name: inference-server-worker
             image: vllm/vllm-openai:latest
             command:
-            - /scripts/entrypoint.sh
+            - sh 
+            - -c 
+            - "bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker --ray_address=$(LWS_LEADER_ADDRESS)"
             env:
             - name: HUGGING_FACE_HUB_TOKEN
               valueFrom:
@@ -78,9 +73,6 @@ spec:
                   name: hf-secret
                   key: hf_api_token
             volumeMounts:
-            - mountPath: "/scripts"
-              name: scripts-volume
-              readOnly: true
             - mountPath: /dev/shm
               name: dshm
         volumes:


### PR DESCRIPTION
There is a new bash script available on the vLLM image to set up multi-host, so this change uses that one instead.

Output yaml, which has been validated:
```
apiVersion: v1
data:
  max_model_len: "8192"
  model_id: meta-llama/Meta-Llama-3.1-405B-Instruct
kind: ConfigMap
metadata:
  name: vllm-multihost-config
---
apiVersion: v1
kind: Service
metadata:
  name: llama3-1-405b-vllm-service
spec:
  ports:
  - name: http
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    role: leader
  type: ClusterIP
---
apiVersion: leaderworkerset.x-k8s.io/v1
kind: LeaderWorkerSet
metadata:
  name: llama3-1-405b-it-lws
spec:
  leaderWorkerTemplate:
    leaderTemplate:
      metadata:
        labels:
          ai.gke.io/model: llama3-1-405b-it
          app: multihost-inference-server
          examples.ai.gke.io/source: blueprints
          role: leader
      spec:
        containers:
        - command:
          - sh
          - -c
          - bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader
            --ray_cluster_size=$(LWS_GROUP_SIZE); python3 -m vllm.entrypoints.openai.api_server
            --port 8080 --model $(MODEL_ID) --tensor-parallel-size $(TENSOR_PARALLEL_SIZE)
            --pipeline_parallel_size $(PIPELINE_PARALLEL_SIZE)
          env:
          - name: HUGGING_FACE_HUB_TOKEN
            valueFrom:
              secretKeyRef:
                key: hf_api_token
                name: hf-secret
          - name: MODEL_ID
            valueFrom:
              configMapKeyRef:
                key: model_id
                name: vllm-multihost-config
          - name: PIPELINE_PARALLEL_SIZE
            value: $(LWS_GROUP_SIZE)
          - name: MAX_MODEL_LEN
            valueFrom:
              configMapKeyRef:
                key: max_model_len
                name: vllm-multihost-config
          - name: TENSOR_PARALLEL_SIZE
            value: "8"
          image: vllm/vllm-openai:latest
          name: inference-server-leader
          ports:
          - containerPort: 8080
            name: metrics
          readinessProbe:
            failureThreshold: 60
            initialDelaySeconds: 15
            periodSeconds: 10
            tcpSocket:
              port: 8080
          resources:
            limits:
              ephemeral-storage: 800Gi
              memory: 1770Gi
              nvidia.com/gpu: "8"
            requests:
              cpu: 125
              ephemeral-storage: 800Gi
          volumeMounts:
          - mountPath: /scripts
            name: scripts-volume
            readOnly: true
          - mountPath: /dev/shm
            name: dshm
        nodeSelector:
          cloud.google.com/gke-accelerator: nvidia-h100-80gb
        volumes:
        - configMap:
            defaultMode: 448
            name: vllm-multihost-config
          name: scripts-volume
        - emptyDir:
            medium: Memory
            sizeLimit: 30Gi
          name: dshm
    restartPolicy: RecreateGroupOnPodRestart
    size: 2
    workerTemplate:
      metadata:
        labels:
          ai.gke.io/model: llama3-1-405b-it
          app: multihost-inference-server
          examples.ai.gke.io/source: blueprints
      spec:
        containers:
        - command:
          - sh
          - -c
          - bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker
            --ray_address=$(LWS_LEADER_ADDRESS)
          env:
          - name: HUGGING_FACE_HUB_TOKEN
            valueFrom:
              secretKeyRef:
                key: hf_api_token
                name: hf-secret
          image: vllm/vllm-openai:latest
          name: inference-server-worker
          resources:
            limits:
              ephemeral-storage: 800Gi
              memory: 1770Gi
              nvidia.com/gpu: "8"
            requests:
              cpu: 125
              ephemeral-storage: 800Gi
          volumeMounts:
          - mountPath: /dev/shm
            name: dshm
        nodeSelector:
          cloud.google.com/gke-accelerator: nvidia-h100-80gb
        volumes:
        - configMap:
            defaultMode: 448
            name: vllm-multihost-config
          name: scripts-volume
        - emptyDir:
            medium: Memory
            sizeLimit: 30Gi
          name: dshm
```
