### PR TITLE
add storage component for gcsfuse support for benchmarking.

### DIFF
--- a/serving-catalog/core/deployment/components/storage/README.md
+++ b/serving-catalog/core/deployment/components/storage/README.md
@@ -1,0 +1,11 @@
+# Storage Component
+
+This directory contains component configuration for storage on the deployment. `base/` contains a template for loading model weights from a PersistentVolumeClaim. The user will need to specify PVC name (PVC_NAME) and model path in the base patch located in `base/deployment.patch.yaml` through a ConfigMap object. The storage component is only targetted to work with vllm at the moment.
+
+## Support
+Current storage component supports the following storage systems:
+
+### GKE
+- GCSFuse
+    - This configuration expects a pre-existing GCSFuse backed PVC (eg: model-pvc)
+    - This configuration will require user to manually add/replace MODEL_PATH value with actual GCS model path.

--- a/serving-catalog/core/deployment/components/storage/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/base/deployment.patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      containers:
+      - name: inference-server
+        env:
+        - name: MODEL_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: model-config
+              key: MODEL_PATH
+        args:
+        - --model=/data/$(MODEL_PATH)
+        volumeMounts:
+        - name: model-data
+          mountPath: /data
+      volumes:
+      - name: model-data
+        persistentVolumeClaim:
+          claimName: PVC_NAME
+        

--- a/serving-catalog/core/deployment/components/storage/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/storage/base/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/storage/gke/gcsfuse/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/gke/gcsfuse/deployment.patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    metadata:
+      annotations:
+        gke-gcsfuse/volumes: "true"
+        gke-gcsfuse/cpu-limit: "0"
+        gke-gcsfuse/memory-request: "0"
+        gke-gcsfuse/memory-limit: "0"
+        gke-gcsfuse/ephemeral-storage-limit: "0"
+    spec:
+      containers:
+      - name: inference-server
+        env:
+          - name: MODEL_PATH
+            value: path/to/model
+            valueFrom:
+              $patch: delete
+      volumes:
+      - name: gke-gcsfuse-cache
+        emptyDir:
+          medium: Memory
+        

--- a/serving-catalog/core/deployment/components/storage/gke/gcsfuse/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/storage/gke/gcsfuse/kustomization.yaml
@@ -1,0 +1,13 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - ../../base
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment


### PR DESCRIPTION
add storage component for gcsfuse support for benchmarking.

The resulting output of the gcs component manifest will look like: (w/ llama3-8b vllm component)
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: llama3-8b-vllm-inference-server
  name: llama3-8b-vllm-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: llama3-8b-vllm-inference-server
  template:
    metadata:
      annotations:
        gke-gcsfuse/cpu-limit: "0"
        gke-gcsfuse/ephemeral-storage-limit: "0"
        gke-gcsfuse/memory-limit: "0"
        gke-gcsfuse/memory-request: "0"
        gke-gcsfuse/volumes: "true"
      labels:
        ai.gke.io/inference-server: vllm
        ai.gke.io/model: LLaMA3_8B
        app: llama3-8b-vllm-inference-server
        examples.ai.gke.io/source: blueprints
    spec:
      containers:
      - args:
        - --model=/data/$(MODEL_PATH)
        command:
        - python3
        - -m
        - vllm.entrypoints.openai.api_server
        env:
        - name: MODEL_PATH
          value: path/to/model
        - name: MODEL_ID
          value: meta-llama/Meta-Llama-3-8B
        - name: HUGGING_FACE_HUB_TOKEN
          valueFrom:
            secretKeyRef:
              key: hf_api_token
              name: hf-secret
        image: vllm/vllm-openai:latest
        name: inference-server
        ports:
        - containerPort: 8000
          name: metrics
        readinessProbe:
          failureThreshold: 60
          httpGet:
            path: /health
            port: 8000
          periodSeconds: 10
        resources:
          limits:
            nvidia.com/gpu: 1
          requests:
            nvidia.com/gpu: 1
        volumeMounts:
        - mountPath: /data
          name: model-data
        - mountPath: /dev/shm
          name: dshm
      nodeSelector:
        cloud.google.com/gke-accelerator: nvidia-l4
      volumes:
      - emptyDir:
          medium: Memory
        name: gke-gcsfuse-cache
      - name: model-data
        persistentVolumeClaim:
          claimName: PVC_NAME
      - emptyDir:
          medium: Memory
        name: dshm
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: llama3-8b-vllm-inference-server
  name: llama3-8b-vllm-service
spec:
  ports:
  - port: 8000
    protocol: TCP
    targetPort: 8000
  selector:
    app: llama3-8b-vllm-inference-server
  type: ClusterIP

---
apiVersion: monitoring.googleapis.com/v1
kind: PodMonitoring
metadata:
  name: vllm-podmonitoring
  labels:
    app: llama3-8b-vllm-inference-server
spec:
  selector:
    matchLabels:
      app: llama3-8b-vllm-inference-server
  endpoints:
  - interval: 15s
    path: "/metrics"
    port: metrics
  targetLabels:
    metadata:
    - pod
    - container
    - node
```