### PR TITLE
Modifying --model addition for storage vllm component as a json patch.

### DIFF
--- a/serving-catalog/core/deployment/components/storage/vllm/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/base/deployment.patch.yaml
@@ -10,8 +10,6 @@ spec:
         env:
         - name: MODEL_PATH
           value: path/to/model
-        args:
-        - --model=/data/$(MODEL_PATH)
         volumeMounts:
         - name: model-data
           mountPath: /data

--- a/serving-catalog/core/deployment/components/storage/vllm/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/base/kustomization.yaml
@@ -8,3 +8,9 @@ patches:
       group: apps
       version: v1
       kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --model=/data/$(MODEL_PATH)
+    target:
+      kind: Deployment


### PR DESCRIPTION
Modifying `--model` addition for storage vllm component as a json add operation patch to prevent overriding other arg flags from vllm model setup.