### PR TITLE
Adding H100 GPU option for larger VLLM model support.

### DIFF
--- a/serving-catalog/core/deployment/components/gke/resources/gpu/8-H100-80GB/h100-80gb.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/8-H100-80GB/h100-80gb.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-h100-80gb
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            nvidia.com/gpu: 8
+          limits:
+            nvidia.com/gpu: 8

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/8-H100-80GB/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/8-H100-80GB/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: h100-80gb.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment


### PR DESCRIPTION
Adding H100 GPU option for larger VLLM model support, particularly llama3-70b.

This is to address issue #35 