### PR TITLE
Adding more storage support for vllm_cache_root.

### DIFF
--- a/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/h100-80gb.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/h100-80gb.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-h100-80gb
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            nvidia.com/gpu: 1
+          limits:
+            nvidia.com/gpu: 1

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: h100-80gb.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/spot/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/spot/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: spot.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/spot/spot.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/spot/spot.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"
+      tolerations:
+      - key: "cloud.google.com/gke-spot"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"

--- a/serving-catalog/core/deployment/components/storage/vllm/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/base/deployment.patch.yaml
@@ -10,9 +10,13 @@ spec:
         env:
         - name: MODEL_PATH
           value: path/to/model
+        - name: VLLM_CACHE_ROOT
+          value: "/data"
+        - name: VLLM_USE_V1
+          value: "1"
         volumeMounts:
         - name: model-data
-          mountPath: /data
+          mountPath: /data/models
       volumes:
       - name: model-data
         persistentVolumeClaim:

--- a/serving-catalog/core/deployment/components/storage/vllm/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/base/kustomization.yaml
@@ -11,6 +11,12 @@ patches:
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --model=/data/$(MODEL_PATH)
+        value: --model=/data/models/$(MODEL_PATH)
+    target:
+      kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --download-dir=/data/models
     target:
       kind: Deployment

--- a/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse/deployment.patch.yaml
@@ -8,7 +8,6 @@ spec:
       annotations:
         gke-gcsfuse/volumes: "true"
         gke-gcsfuse/cpu-limit: "0"
-        gke-gcsfuse/memory-request: "0"
         gke-gcsfuse/memory-limit: "0"
         gke-gcsfuse/ephemeral-storage-limit: "0"
     spec:


### PR DESCRIPTION
Adding more storage support for vllm_cache_root.
Additionally:
1.  remove `gke-gcsfuse/memory-request: "0"` from gcsfuse component configuration. Was getting messages/errors:
```
The node was low on resource: memory. Threshold quantity: 100Mi, available: -44464Ki. Container gke-gcsfuse-sidecar was using 9887856Ki, request is 0, has larger consumption of memory. Container inference-server was using 1311072Ki, request is 0, has larger consumption of memory. 
```
2. Introduce 1 GPU request/limit for nvidia-h100-80gb accelerator.
3. Add `spot` component for preemtible usage.