### PR TITLE
Seperate gcsfuse ram cache feature.

### DIFF
--- a/serving-catalog/core/deployment/components/storage/vllm/README.md
+++ b/serving-catalog/core/deployment/components/storage/vllm/README.md
@@ -9,3 +9,4 @@ Current storage component supports the following storage systems:
 - GCSFuse
     - This configuration expects a pre-existing GCSFuse backed PVC (eg: model-pvc)
     - This configuration will require user to manually add/replace MODEL_PATH value with actual GCS model path.
+    - To change file cache from LSSD to RAM, Use the `gcsfuse-ram-cache` component.

--- a/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse-ram-cache/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse-ram-cache/deployment.patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      volumes:
+      - name: gke-gcsfuse-cache
+        emptyDir:
+          medium: Memory
+        

--- a/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse-ram-cache/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse-ram-cache/kustomization.yaml
@@ -1,0 +1,13 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - ../gcsfuse
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/components/storage/vllm/gke/gcsfuse/deployment.patch.yaml
@@ -10,9 +10,4 @@ spec:
         gke-gcsfuse/cpu-limit: "0"
         gke-gcsfuse/memory-limit: "0"
         gke-gcsfuse/ephemeral-storage-limit: "0"
-    spec:
-      volumes:
-      - name: gke-gcsfuse-cache
-        emptyDir:
-          medium: Memory
         

--- a/serving-catalog/core/deployment/vllm/llama3-8b/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/vllm/llama3-8b/base/kustomization.yaml
@@ -21,4 +21,4 @@ patches:
       path: /spec/template/spec/containers/0/args/-
       value: --tensor-parallel-size=1
   target:
-    kind: deployment
+    kind: Deployment


### PR DESCRIPTION
Seperate gcsfuse ram cache feature. Some accelerators won't be able to support gke-gcsfuse-cache due to model size being greater than the machine's RAM memory. 

Additionally, fix `Deployment` capitalization on llama3-8b vllm.