### PR TITLE
Add aks deployment

### DIFF
--- a/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: t4.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/t4.yaml
+++ b/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/t4.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.azure.com/accelerator: nvidia
+      containers:
+      - name: inference-server
+        # resources:
+        #   requests:
+        #     nvidia.com/gpu: 1
+        #   limits:
+        #     nvidia.com/gpu: 1

--- a/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/t4.yaml
+++ b/serving-catalog/core/deployment/components/aks/resources/gpu/1-T4/t4.yaml
@@ -9,8 +9,8 @@ spec:
         kubernetes.azure.com/accelerator: nvidia
       containers:
       - name: inference-server
-        # resources:
-        #   requests:
-        #     nvidia.com/gpu: 1
-        #   limits:
-        #     nvidia.com/gpu: 1
+        resources:
+          requests:
+            nvidia.com/gpu: 1
+          limits:
+            nvidia.com/gpu: 1

--- a/serving-catalog/core/deployment/vllm/gemma-2b/aks/README.md
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/aks/README.md
@@ -1,0 +1,14 @@
+# Gemma-2b
+
+## Configuration
+| Kind | Model Server | Model | Provider | Accelerator |
+| --- | --- | --- | --- | --- |
+| Deployment | vLLM | gemma-2b | AKS | GPU T4 |
+
+## Usage
+
+The template can be deployed with the following commands:
+
+```
+kustomize build core/deployment/vllm/gemma-2b/aks | kubectl apply -f -
+```

--- a/serving-catalog/core/deployment/vllm/gemma-2b/aks/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/aks/deployment.patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    metadata:
+      labels:
+        ai.gke.io/model: gemma-2b
+        ai.gke.io/inference-server: vllm
+        examples.ai.gke.io/source: blueprints

--- a/serving-catalog/core/deployment/vllm/gemma-2b/aks/hpa.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/aks/hpa.patch.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /metadata/name
+  value: gemma-2b-vllm-hpa
+- op: add
+  path: /metadata/labels
+  value:
+    app: gemma-2b-vllm-inference-server
+- op: add
+  path: /spec/metrics/0/pods/target/averageValue
+  value: 50

--- a/serving-catalog/core/deployment/vllm/gemma-2b/aks/kustomization.yaml
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/aks/kustomization.yaml
@@ -1,0 +1,19 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ../../../components/aks/resources/gpu/1-T4
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      kind: Deployment
+  - options:
+      allowNameChange: true
+    path: hpa.patch.yaml
+    target:
+      kind: HorizontalPodAutoscaler


### PR DESCRIPTION
- Added AKS support for Gemma-2b
- Selected NVIDIA T4 GPU for deployment, as L4 GPUs are not available in Azure.