### PR TITLE
Adding v6e machine type for deployments

### DIFF
--- a/serving-catalog/core/deployment/components/gke/resources/tpu/v6e-2x4/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/tpu/v6e-2x4/kustomization.yaml
@@ -1,0 +1,10 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: v6e-2x4.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/tpu/v6e-2x4/v6e-2x4.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/tpu/v6e-2x4/v6e-2x4.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 2x4
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            google.com/tpu: 8
+          limits:
+            google.com/tpu: 8


### PR DESCRIPTION
Sample output on vLLM Llama3 8B 

```apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: llama3-8b-vllm-inference-server
  name: llama3-8b-vllm-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: llama3-8b-vllm-inference-server
  template:
    metadata:
      labels:
        ai.gke.io/inference-server: vllm
        ai.gke.io/model: LLaMA3_8B
        app: llama3-8b-vllm-inference-server
        examples.ai.gke.io/source: blueprints
    spec:
      containers:
      - args:
        - --model=$(MODEL_ID)
        command:
        - python3
        - -m
        - vllm.entrypoints.openai.api_server
        env:
        - name: MODEL_ID
          value: meta-llama/Meta-Llama-3-8B
        - name: HUGGING_FACE_HUB_TOKEN
          valueFrom:
            secretKeyRef:
              key: hf_api_token
              name: hf-secret
        image: vllm/vllm-openai:latest
        name: inference-server
        ports:
        - containerPort: 8000
          name: metrics
        readinessProbe:
          failureThreshold: 60
          httpGet:
            path: /health
            port: 8000
          periodSeconds: 10
        resources:
          limits:
            google.com/tpu: 8
          requests:
            google.com/tpu: 8
        volumeMounts:
        - mountPath: /dev/shm
          name: dshm
      nodeSelector:
        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
        cloud.google.com/gke-tpu-topology: 2x4
      volumes:
      - emptyDir:
          medium: Memory
        name: dshm
```