### PR TITLE
Remove irrelevant nodeselectors for 1-H100-80GB

### DIFF
--- a/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/h100-80gb.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/1-H100-80GB/h100-80gb.yaml
@@ -7,7 +7,6 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-h100-80gb
-        cloud.google.com/compute-class: "Accelerator"
       containers:
       - name: inference-server
         resources:


### PR DESCRIPTION
Followup to https://github.com/kubernetes-sigs/wg-serving/pull/43