### PR TITLE
fix: add deployment-name selectors to services

### DIFF
--- a/serving-catalog/core/deployment/base/deployment.yaml
+++ b/serving-catalog/core/deployment/base/deployment.yaml
@@ -7,10 +7,12 @@ spec:
   selector:
     matchLabels:
       app: singlehost-inference-server
+      deployment: singlehost-inference-deployment-blueprint
   template:
     metadata:
       labels:
         app: singlehost-inference-server
+        deployment: singlehost-inference-deployment-blueprint
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/jetstream/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/base/deployment.patch.yaml
@@ -7,10 +7,12 @@ spec:
   selector:
     matchLabels:
       app: maxengine-server
+      deployment: maxengine-server
   template:
     metadata:
       labels:
         app: maxengine-server
+        deployment: maxengine-server
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/jetstream/base/service.yaml
+++ b/serving-catalog/core/deployment/jetstream/base/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: maxengine-server
+    deployment: maxengine-server
   ports:
   - protocol: TCP
     name: jetstream-http

--- a/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/deployment.patch.yaml
@@ -8,10 +8,12 @@ spec:
   selector:
     matchLabels:
       app: gemma-7b-it-jetstream-inference-server
+      deployment: gemma-7b-it-jetstream-deployment
   template:
     metadata:
       labels:
         app: gemma-7b-it-jetstream-inference-server
+        deployment: gemma-7b-it-jetstream-deployment
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/gemma-7b-it/base/service.patch.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   selector:
     app: gemma-7b-it-jetstream-inference-server
+    deployment: gemma-7b-it-jetstream-deployment

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/deployment.patch.yaml
@@ -8,10 +8,12 @@ spec:
   selector:
     matchLabels:
       app: llama3-8b-jetstream-inference-server
+      deployment: llama3-8b-jetstream-deployment
   template:
     metadata:
       labels:
         app: llama3-8b-jetstream-inference-server
+        deployment: llama3-8b-jetstream-deployment
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/jetstream/llama3-8b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/jetstream/llama3-8b/base/service.patch.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   selector:
     app: llama3-8b-jetstream-inference-server
+    deployment: llama3-8b-jetstream-deployment

--- a/serving-catalog/core/deployment/vllm/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/base/deployment.patch.yaml
@@ -6,10 +6,12 @@ spec:
   selector:
     matchLabels:
       app: vllm-server
+      deployment: vllm-deployment-blueprint
   template:
     metadata:
       labels:
         app: vllm-server
+        deployment: vllm-deployment-blueprint
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/vllm/base/service.yaml
+++ b/serving-catalog/core/deployment/vllm/base/service.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: vllm-server
+    deployment: vllm-deployment-blueprint
   type: ClusterIP
   ports:
     - protocol: TCP

--- a/serving-catalog/core/deployment/vllm/gemma-2b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/base/deployment.patch.yaml
@@ -2,16 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: gemma-2b-vllm-inference-server
+    app: gemma-2b-vllm-inference-server
   name: gemma-2b-vllm-deployment
 spec:
   selector:
     matchLabels:
       app: gemma-2b-vllm-inference-server
+      deployment: gemma-2b-vllm-deployment
   template:
     metadata:
       labels:
         app: gemma-2b-vllm-inference-server
+        deployment: gemma-2b-vllm-deployment
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/vllm/gemma-2b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/gemma-2b/base/service.patch.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   selector:
     app: gemma-2b-vllm-inference-server
+    deployment: gemma-2b-vllm-deployment

--- a/serving-catalog/core/deployment/vllm/llama3-70b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/llama3-70b/base/deployment.patch.yaml
@@ -8,10 +8,12 @@ spec:
   selector:
     matchLabels:
       app: llama3-70b-vllm-inference-server
+      deployment: llama3-70b-vllm-deployment
   template:
     metadata:
       labels:
         app: llama3-70b-vllm-inference-server
+        deployment: llama3-70b-vllm-deployment
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/vllm/llama3-70b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/llama3-70b/base/service.patch.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   selector:
     app: llama3-70b-vllm-inference-server
+    deployment: llama3-70b-vllm-deployment

--- a/serving-catalog/core/deployment/vllm/llama3-8b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/llama3-8b/base/deployment.patch.yaml
@@ -8,10 +8,12 @@ spec:
   selector:
     matchLabels:
       app: llama3-8b-vllm-inference-server
+      deployment: llama3-8b-vllm-deployment
   template:
     metadata:
       labels:
         app: llama3-8b-vllm-inference-server
+        deployment: llama3-8b-vllm-deployment
     spec:
       containers:
       - name: inference-server

--- a/serving-catalog/core/deployment/vllm/llama3-8b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/llama3-8b/base/service.patch.yaml
@@ -7,3 +7,4 @@ metadata:
 spec:
   selector:
     app: llama3-8b-vllm-inference-server
+    deployment: llama3-8b-vllm-deployment

--- a/serving-catalog/core/lws/base/leaderworkerset.yaml
+++ b/serving-catalog/core/lws/base/leaderworkerset.yaml
@@ -10,6 +10,7 @@ spec:
         labels:
           app: multihost-inference-server
           role: leader
+          deployment: vllm-multihost-base
       spec:
         containers:
           - name: multihost-leader-base

--- a/serving-catalog/core/lws/vllm/base/leaderworkerset.patch.yaml
+++ b/serving-catalog/core/lws/vllm/base/leaderworkerset.patch.yaml
@@ -6,6 +6,9 @@ spec:
   leaderWorkerTemplate:
     restartPolicy: RecreateGroupOnPodRestart
     leaderTemplate:
+      metadata:
+        labels:
+          deployment: vllm-multihost-base
       spec:
         containers:
           - name: inference-server-leader

--- a/serving-catalog/core/lws/vllm/base/service.yaml
+++ b/serving-catalog/core/lws/vllm/base/service.yaml
@@ -10,4 +10,5 @@ spec:
       targetPort: 8080
   selector:
     role: leader
+    deployment: vllm-multihost-base
   type: ClusterIP

--- a/serving-catalog/core/lws/vllm/deepseek-r1/gke/leaderworkerset.patch.yaml
+++ b/serving-catalog/core/lws/vllm/deepseek-r1/gke/leaderworkerset.patch.yaml
@@ -10,6 +10,8 @@ spec:
         labels:
           ai.gke.io/model: deepseek-r1
           examples.ai.gke.io/source: blueprints
+          role: leader
+          deployment: vllm-multihost-base
     workerTemplate:
       metadata:
         labels:

--- a/serving-catalog/core/lws/vllm/llama3.1-405b-it/gke/leaderworkerset.patch.yaml
+++ b/serving-catalog/core/lws/vllm/llama3.1-405b-it/gke/leaderworkerset.patch.yaml
@@ -10,6 +10,8 @@ spec:
         labels:
           ai.gke.io/model: llama3-1-405b-it
           examples.ai.gke.io/source: blueprints
+          role: leader
+          deployment: vllm-multihost-base
     workerTemplate:
       metadata:
         labels:


### PR DESCRIPTION
## Summary
This PR fixes [#28](https://github.com/kubernetes-sigs/wg-serving/issues/28) by ensuring Services only target pods from their corresponding Deployment.

## Changes
- Added unique `deployment` label in all affected Deployments (vllm, jetstream, gemma-7b-it, llama3-8b).
- Updated Service selectors to include the new `deployment` label.
- Prevents Services from routing traffic to pods belonging to other models on the same server.

## Why
Previously, Services selected pods too broadly (e.g., only `app: vllm-server`), which caused traffic from one Service to be sent to multiple model Deployments. This change isolates traffic properly.
