### PR TITLE
Add `TopologySpreadConstraints` to vLLM base

### DIFF
--- a/serving-catalog/core/deployment/vllm/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/base/deployment.patch.yaml
@@ -35,6 +35,13 @@ spec:
             port: 8000
           failureThreshold: 60
           periodSeconds: 10
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            ai.gke.io/inference-server : vllm
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: dshm
         emptyDir:


### PR DESCRIPTION
Prevents a memory pressure when deploying multiple vLLM instances since multiple vLLM deployments may attempt to schedule multiple pods on a single node.