### PR TITLE
Add rest of gke GPU resource components

### DIFF
--- a/serving-catalog/core/deployment/components/gke/resources/gpu/2-H200-141GB/h200-141gb.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/2-H200-141GB/h200-141gb.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-h200-141gb
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            nvidia.com/gpu: 2
+          limits:
+            nvidia.com/gpu: 2

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/2-H200-141GB/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/2-H200-141GB/kustomization.yaml
@@ -1,0 +1,18 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: h200-141gb.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: TENSOR_PARALLEL_SIZE
+          value: "2"
+    target:
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/4-H200-141GB/h200-141gb.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/4-H200-141GB/h200-141gb.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-h200-141gb
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            nvidia.com/gpu: 4
+          limits:
+            nvidia.com/gpu: 4

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/4-H200-141GB/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/4-H200-141GB/kustomization.yaml
@@ -1,0 +1,18 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: h200-141gb.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: TENSOR_PARALLEL_SIZE
+          value: "4"
+    target:
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/4-L4/kustomization.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/4-L4/kustomization.yaml
@@ -1,0 +1,18 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: l4.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: TENSOR_PARALLEL_SIZE
+          value: "4"
+    target:
+      kind: Deployment

--- a/serving-catalog/core/deployment/components/gke/resources/gpu/4-L4/l4.yaml
+++ b/serving-catalog/core/deployment/components/gke/resources/gpu/4-L4/l4.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-l4
+      containers:
+      - name: inference-server
+        resources:
+          requests:
+            nvidia.com/gpu: 4
+          limits:
+            nvidia.com/gpu: 4


### PR DESCRIPTION
Added components such that all combinations of {1,2,4,8} x {"nvidia-tesla-a100", "nvidia-h100-80gb", "nvidia-h200-141gb", "nvidia-l4"} are supported. Follow up to https://github.com/kubernetes-sigs/wg-serving/pull/58