### PR TITLE
Add TinyLlama model support for GKE

### DIFF
--- a/serving-catalog/catalog.md
+++ b/serving-catalog/catalog.md
@@ -5,4 +5,5 @@
 | Deployment | [vLLM](https://github.com/vllm-project/vllm) | gemma-2b | GKE | [README](./core/deployment/vllm/gemma-2b/gke/README.md) |
 | Deployment | [vLLM](https://github.com/vllm-project/vllm) | llama3-8b | GKE | [README](./core/deployment/vllm/llama3-8b/gke/README.md) |
 | Deployment | [vLLM](https://github.com/vllm-project/vllm) | llama3-70b | GKE | [README](./core/deployment/vllm/llama3-70b/gke/README.md) |
+| Deployment | [vLLM](https://github.com/vllm-project/vllm) | tinyllama-1.1b | GKE | [README](./core/deployment/vllm/tinyllama-1.1b/gke/README.md) |
 | Deployment | [JetStream](https://github.com/google/JetStream) | gemma-7b-it | GKE | [README](./core/deployment/jetstream/gemma-7b-it/gke/README.md) |

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
@@ -19,4 +19,4 @@ spec:
       - name: inference-server
         env:
           - name: MODEL_ID
-            value: TinyLlama/TinyLlama-1b-Chat-v1.0
+            value: 'TinyLlama/TinyLlama-1.1b-Chat-v1.0'

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tinyllama-1.1b-vllm-inference-server
+  name: tinyllama-1.1b-vllm-deployment
+spec:
+  selector:
+    matchLabels:
+      app: tinyllama-1.1b-vllm-inference-server
+      deployment: tinyllama-1.1b-vllm-deployment
+  template:
+    metadata:
+      labels:
+        app: tinyllama-1.1b-vllm-inference-server
+        deployment: tinyllama-1.1b-vllm-deployment
+    spec:
+      containers:
+      - name: inference-server
+        env:
+          - name: MODEL_ID
+            value: TinyLlama/TinyLlama-1.1B-Chat-v1.0

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/deployment.patch.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: tinyllama-1.1b-vllm-inference-server
-  name: tinyllama-1.1b-vllm-deployment
+    app: tinyllama-1b-vllm-inference-server
+  name: tinyllama-1b-vllm-deployment
 spec:
   selector:
     matchLabels:
-      app: tinyllama-1.1b-vllm-inference-server
-      deployment: tinyllama-1.1b-vllm-deployment
+      app: tinyllama-1b-vllm-inference-server
+      deployment: tinyllama-1b-vllm-deployment
   template:
     metadata:
       labels:
-        app: tinyllama-1.1b-vllm-inference-server
-        deployment: tinyllama-1.1b-vllm-deployment
+        app: tinyllama-1b-vllm-inference-server
+        deployment: tinyllama-1b-vllm-deployment
     spec:
       containers:
       - name: inference-server
         env:
           - name: MODEL_ID
-            value: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+            value: TinyLlama/TinyLlama-1b-Chat-v1.0

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/kustomization.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/kustomization.yaml
@@ -1,0 +1,18 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patches:
+- options:
+    allowNameChange: true
+  path: deployment.patch.yaml
+  target:
+    kind: Deployment
+- options:
+    allowNameChange: true
+  path: service.patch.yaml
+  target:
+    kind: Service

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/service.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tinyllama-1.1b-vllm-service
+  labels:
+    app: tinyllama-1.1b-vllm-inference-server
+spec:
+  selector:
+    app: tinyllama-1.1b-vllm-inference-server
+    deployment: tinyllama-1.1b-vllm-deployment

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/service.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/base/service.patch.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: tinyllama-1.1b-vllm-service
+  name: tinyllama-1b-vllm-service
   labels:
-    app: tinyllama-1.1b-vllm-inference-server
+    app: tinyllama-1b-vllm-inference-server
 spec:
   selector:
-    app: tinyllama-1.1b-vllm-inference-server
-    deployment: tinyllama-1.1b-vllm-deployment
+    app: tinyllama-1b-vllm-inference-server
+    deployment: tinyllama-1b-vllm-deployment

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/README.md
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/README.md
@@ -1,0 +1,14 @@
+# TinyLlama-1.1b
+
+## Configuration
+| Kind | Model Server | Model | Provider | Accelerator |
+| --- | --- | --- | --- | --- |
+| Deployment | vLLM | tinyllama-1.1b | GKE | GPU L4 |
+
+## Usage
+
+The template can be deployed with the following commands:
+
+```
+kustomize build core/deployment/vllm/tinyllama-1.1b/gke | kubectl apply -f -
+```

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/deployment.patch.yaml
@@ -6,6 +6,6 @@ spec:
   template:
     metadata:
       labels:
-        ai.gke.io/model: tinyllama-1.1b
+        ai.gke.io/model: tinyllama-1b
         ai.gke.io/inference-server: vllm
         examples.ai.gke.io/source: blueprints

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/deployment.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/deployment.patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '*'
+spec:
+  template:
+    metadata:
+      labels:
+        ai.gke.io/model: tinyllama-1.1b
+        ai.gke.io/inference-server: vllm
+        examples.ai.gke.io/source: blueprints

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/hpa.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/hpa.patch.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /metadata/name
+  value: tinyllama-1.1b-vllm-hpa
+- op: add
+  path: /metadata/labels
+  value:
+    app: tinyllama-1.1b-vllm-inference-server
+- op: add
+  path: /spec/metrics/0/pods/target/averageValue
+  value: 50

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/hpa.patch.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/hpa.patch.yaml
@@ -1,10 +1,10 @@
 - op: add
   path: /metadata/name
-  value: tinyllama-1.1b-vllm-hpa
+  value: tinyllama-1b-vllm-hpa
 - op: add
   path: /metadata/labels
   value:
-    app: tinyllama-1.1b-vllm-inference-server
+    app: tinyllama-1b-vllm-inference-server
 - op: add
   path: /spec/metrics/0/pods/target/averageValue
   value: 50

--- a/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/kustomization.yaml
+++ b/serving-catalog/core/deployment/vllm/tinyllama-1.1b/gke/kustomization.yaml
@@ -1,0 +1,20 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ../../../components/gke/resources/gpu/1-L4
+  # - ../../../components/hpa/vllm/token-latency # HPA is a work-in-progress
+
+patches:
+  - path: deployment.patch.yaml
+    target:
+      kind: Deployment
+  - options:
+      allowNameChange: true
+    path: hpa.patch.yaml
+    target:
+      kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Added support [TinyLlama-1.1B-Chat-v1.0](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0) for GKE.
Rendered deployment manifest:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: tinyllama-1b-vllm-inference-server
  name: tinyllama-1b-vllm-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: tinyllama-1b-vllm-inference-server
      deployment: tinyllama-1b-vllm-deployment
  template:
    metadata:
      labels:
        ai.gke.io/inference-server: vllm
        ai.gke.io/model: tinyllama-1b
        app: tinyllama-1b-vllm-inference-server
        deployment: tinyllama-1b-vllm-deployment
        examples.ai.gke.io/source: blueprints
    spec:
      containers:
      - args:
        - --model=$(MODEL_ID)
        - --tensor-parallel-size=$(TENSOR_PARALLEL_SIZE)
        command:
        - python3
        - -m
        - vllm.entrypoints.openai.api_server
        env:
        - name: MODEL_ID
          value: TinyLlama/TinyLlama-1.1b-Chat-v1.0
        - name: HUGGING_FACE_HUB_TOKEN
          valueFrom:
            secretKeyRef:
              key: hf_api_token
              name: hf-secret
        - name: TENSOR_PARALLEL_SIZE
          value: "1"
        image: vllm/vllm-openai:v0.8.5
        name: inference-server
        ports:
        - containerPort: 8000
          name: metrics
        readinessProbe:
          failureThreshold: 60
          httpGet:
            path: /health
            port: 8000
          periodSeconds: 10
        resources:
          limits:
            nvidia.com/gpu: 1
          requests:
            nvidia.com/gpu: 1
        volumeMounts:
        - mountPath: /dev/shm
          name: dshm
      nodeSelector:
        cloud.google.com/gke-accelerator: nvidia-l4
      volumes:
      - emptyDir:
          medium: Memory
        name: dshm
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: tinyllama-1b-vllm-inference-server
  name: tinyllama-1b-vllm-service
spec:
  ports:
  - port: 8000
    protocol: TCP
    targetPort: 8000
  selector:
    app: tinyllama-1b-vllm-inference-server
    deployment: tinyllama-1b-vllm-deployment
  type: ClusterIP
```